### PR TITLE
fix: smartbanner should put margin on <body> Tag

### DIFF
--- a/src/detector.js
+++ b/src/detector.js
@@ -17,7 +17,7 @@ export default class Detector {
   }
 
   static wrapperElement() {
-    let selector = Detector.jQueryMobilePage() ? '.ui-page' : 'html';
+    let selector = Detector.jQueryMobilePage() ? '.ui-page' : 'html>body';
     return document.querySelectorAll(selector);
   }
 


### PR DESCRIPTION
bugfix for #95 :  smartbanner puts margin on <html> tag, but should on <body> 